### PR TITLE
  Add trailing slash to trigger the evaluation of postData.ori and get back an array of plain JS objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ node_modules/
 index.html
 feed.json
 build/
+buildOri/
 .env
 notez/

--- a/origami/site.ori
+++ b/origami/site.ori
@@ -1,3 +1,3 @@
 {
-  index.html = index.js(postData.ori)
+  index.html = index.js(postData.ori/)
 }


### PR DESCRIPTION
_After our call last week, I submitted this PR for your review… but today discovered that I had somehow managed to submit a PR against my own fork of your repo. Trying again…_

In our call we wrote the line:

```
index.html = index.js(postData.ori)
```

What this expression does is load postData.ori as a file buffer and then try to pass that to index.js. That makes no sense — index.js expects an array of plain JS objects representing notes.

What we wanted to do was *evaluate* the contents of `postData.ori` as an expression. We can do that by adding a trailing slash:

```
index.html = index.js(postData.ori/)
```

The trailing slash says: "Give me the root of the tree in postData.ori." This returns the desired array of plain JS objects. This is then passed to index.js. So now running `npm run buildOri` from the project root works as expected.