### PR TITLE
Use a seeded pseudo-random number generator to pick a random post ID based on page content

### DIFF
--- a/src/data/site-data.ori
+++ b/src/data/site-data.ori
@@ -10,4 +10,7 @@
   home_page_url: "https://notes.jim-nielsen.com"
   feed_url: "https://notes.jim-nielsen.com/feed.json"
   items: <md-to-data.ori>/
+
+  // For use elsewhere in the generation of the site, just grab the IDs
+  _item_ids: Tree.plain(Tree.map(items, (post) => post.id.includes("T") ? post.id.replace("T", "-") : post.id))
 }

--- a/src/site.ori
+++ b/src/site.ori
@@ -1,7 +1,7 @@
 {
   // Private vars
   (site) = <data/site-data.ori>
-  (site_truncated) = {...site, items: Tree.take(site.items, 20) }
+  (site_truncated) = {...site, items: Tree.take(site.items, 20), _item_ids: undefined }
 
   // Public files
   ...(<../static>),
@@ -9,6 +9,7 @@
   feed.xml = Origami.rss(site_truncated)
   index.html = <routes/index.ori>(site)
 
+  // Individual note routes
   n = {
     index.html: <routes/n.index.ori>(site)
     ...Tree.map(site.items, {

--- a/src/templates/Page.ori.html
+++ b/src/templates/Page.ori.html
@@ -103,7 +103,7 @@
     <script type="module">
       // Get all the post IDs
       // @TODO: remove when all posts have been converted from `T` format
-      const postsIds = ${JSON.stringify(Tree.plain(Tree.map(_.site.items, (post) => post.id.includes("T") ? post.id.replace("T", "-") : post.id)))};
+      const postsIds = ${JSON.stringify(_.site._item_ids)};
 
       // Randomly select one of the postsIds
       const randomPostId = postsIds[Math.floor(Math.random() * postsIds.length)];


### PR DESCRIPTION
I did this experiment mostly to see if it would work — and it worked out rather well, so I figured I'd send it to you. A PR seemed like the easiest way to share this idea, but look at this as a napkin sketch you can toss out; I've already gotten what I wanted out of this.

The core idea here is that static sites that want "random" elements should do so using a seeded pseudo-random number generator (pRNG). If you're not familiar with those: all random number generators like `Math.random` have to start with some initial "seed" number to pick their first number. In practice this seed is calculated from various bits and bobs like the time, your IP, whatever. So each time you call `Math.random`, you start with a different number.

With a seeded pRNG, _you_ pick the seed value to get a custom function. That seed value will get crunched with a bunch of math to become the first "random" number picked by the function. Each subsequent calls to the function uses the previous value to compute the next.

This PR includes a `random.js` function that's a placeholder for a hypothetical Origami builtin function, and implements a seeded pRNG. You give it either raw bytes (like a file) or text as the seed content and it gives you back a function. Call that function to get a pseudo-random number that depends on that seed content. The key thing is that _every time_ you use that seed content, you get back a function that will give you the _same_ sequence of pseudo-random numbers.

As a sample application, `templates/randomId.ori` uses the above `random.js` to pick a random note ID for a given chunk of text (the `children`) of a page. The earlier client-side JS to pick an ID can be removed, so there's less client-side JS overall.

The `Page.ori.html` template makes use of that `randomId.ori` to inject that random (but stable!) note ID into the `<a>` tag's `href`.

Example using the current site:
1. Home page random note link goes to 2026-02-16-2317, click that link
2. That page's random note link goes to 2023-11-01-2005, click that link
3. That page's random note link goes to 2018-05-04-1229 …

The important bit is that this same sequence will repeated for every build as long as page content isn't changing. If you change the page template or post text, that will change the sequence. Side effect: each time you add a note, the content of the home page changes… which means the home page's random href will change. I think that's a nice bonus.

Adding a new note will leave all the other page's untouched — so when you build, `Dev.changes` should report that they're the same. Since most of the site stays constant, Netlify deployments should stay fast.

Best part: **build time is cut by over 90%**. 

51s before
4s after

I think most of the slowness of what's on #main is likely in the calculation of `postsIds`. Doing a map over all the posts, then normalizing IDs, and converting to JSON was likely quite expensive, especially when done for each page.

If you want to land this as is, great. If this works out for you, I'll look at promoting `random.js` to a builtin that you could use for this purpose.

If the idea is appealing but you want help changing how the idea is expressed, I'm happy to help.