### PR TITLE
fix: generate list of note IDs once

### DIFF
--- a/src/data/site-data.ori
+++ b/src/data/site-data.ori
@@ -10,4 +10,7 @@
   home_page_url: "https://notes.jim-nielsen.com"
   feed_url: "https://notes.jim-nielsen.com/feed.json"
   items: <md-to-data.ori>/
+
+  // For use elsewhere in the generation of the site, just grab the IDs
+  _item_ids: Tree.plain(Tree.map(items, (post) => post.id.includes("T") ? post.id.replace("T", "-") : post.id))
 }

--- a/src/site.ori
+++ b/src/site.ori
@@ -1,7 +1,7 @@
 {
   // Private vars
   (site) = <data/site-data.ori>
-  (site_truncated) = {...site, items: Tree.take(site.items, 20) }
+  (site_truncated) = {...site, items: Tree.take(site.items, 20), _item_ids: undefined }
 
   // Public files
   ...(<../static>),
@@ -9,6 +9,7 @@
   feed.xml = Origami.rss(site_truncated)
   index.html = <routes/index.ori>(site)
 
+  // Individual note routes
   n = {
     index.html: <routes/n.index.ori>(site)
     ...Tree.map(site.items, {

--- a/src/templates/Page.ori.html
+++ b/src/templates/Page.ori.html
@@ -103,7 +103,7 @@
     <script type="module">
       // Get all the post IDs
       // @TODO: remove when all posts have been converted from `T` format
-      const postsIds = ${JSON.stringify(Tree.plain(Tree.map(_.site.items, (post) => post.id.includes("T") ? post.id.replace("T", "-") : post.id)))};
+      const postsIds = ${JSON.stringify(_.site._item_ids)};
 
       // Randomly select one of the postsIds
       const randomPostId = postsIds[Math.floor(Math.random() * postsIds.length)];


### PR DESCRIPTION
From ~40s to ~2s. Thanks @JanMiksovsky 

Before:

`npm run build 40.83s user 1.19s system 155% cpu 26.987 total`

After:

`npm run build  2.01s user 0.54s system 42% cpu 6.020 total`